### PR TITLE
Add Windows 11 version 22H2

### DIFF
--- a/NewModernWinver/ListsAndStuff.cs
+++ b/NewModernWinver/ListsAndStuff.cs
@@ -25,8 +25,8 @@ namespace NewModernWinver
             { 19044, "21H2" },
             { 20348, "21H2" },
             { 21996, "Stop using leaked builds" },
-            { 22000, "21H2" }
-
+            { 22000, "21H2" },
+            { 22621, "21H2" }
         };
 
         public static Dictionary<int, string> EditionDict = new Dictionary<int, string>

--- a/NewModernWinver/ListsAndStuff.cs
+++ b/NewModernWinver/ListsAndStuff.cs
@@ -26,7 +26,7 @@ namespace NewModernWinver
             { 20348, "21H2" },
             { 21996, "Stop using leaked builds" },
             { 22000, "21H2" },
-            { 22621, "21H2" }
+            { 22621, "22H2" }
         };
 
         public static Dictionary<int, string> EditionDict = new Dictionary<int, string>


### PR DESCRIPTION
https://blogs.windows.com/windows-insider/2022/06/07/releasing-windows-11-version-22h2-to-the-release-preview-channel/